### PR TITLE
ALPN timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # update local dev library for openssl
 RUN apt-get update
-RUN apt-get install -y wget openssl libssl-dev
+RUN apt-get install -y wget openssl libssl-dev coreutils
 
 # install our essentials to build openssl
 RUN apt-get install -y build-essential

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ cd /tmp/openssl-1.0.2h && make install
 rm -R /tmp/openssl-1.0.2h
 ```
 
+The module also expects to see `timeout` from `coreutils` present in some form, this defaults to `gtimeout` on MacOS which can be installed using:
+
+```
+brew install coreutils
+```
+
 ## Rules
 
 Rules represent checks that occur in this module, all of these rules have a **UID** which can be used to check for specific rules. For the structure and more details see the [Wiki](https://github.com/passmarked/passmarked/wiki) page on [Rules](https://github.com/passmarked/passmarked/wiki/Create).

--- a/lib/rules/alpn.js
+++ b/lib/rules/alpn.js
@@ -4,6 +4,7 @@ const S             = require('string');
 const url           = require('url');
 const async         = require('async');
 const childProcess  = require('child_process');
+const os            = require('os');
 
 // compile regex variable for us to use
 var alpnRegex = new RegExp(/alpn\s+protocol\:\s+(.*)/gim);
@@ -12,10 +13,36 @@ var alpnRegex = new RegExp(/alpn\s+protocol\:\s+(.*)/gim);
 module.exports = exports = function(payload, fn) {
 
   // get the data
-  var data      = payload.getData();
+  var data              = payload.getData();
 
   // parse the url
-  var uri       = url.parse(data.redirected || data.url);
+  var uri               = url.parse(data.redirected || data.url);
+
+  // the path for timeout
+  var platform          = os.platform();
+  var timeoutCommand    = 'timeout';
+
+  // fallback to gtimeout on osx
+  if(platform === 'linux') {
+
+    // set to gtimeout
+    timeoutCommand = 'timeout';
+
+  } else if(platform === 'darwin') {
+
+    // set to gtimeout
+    timeoutCommand = 'gtimeout';
+
+  } else {
+
+    // output warning
+    payload.warning('Was not able to run ALPN check, supported' + 
+      ' platforms are only linux/MacOS at this time');
+
+    // fail right here
+    return fn(null);
+
+  }
 
   // build the commands to send
   var args      = [ 
@@ -23,12 +50,16 @@ module.exports = exports = function(payload, fn) {
     'echo', 
     'QUIT', 
     '|', 
-    '/usr/local/ssl/bin/openssl', // default install for our compiled version
+    timeoutCommand,
+    '5',
+    process.env.PASSMARKED_OPENSSL_PATH || '/usr/local/ssl/bin/openssl', // default install for our compiled version
     's_client', 
     '-connect', 
-    uri.host + ':' + (uri.port || 443), 
+    uri.hostname + ':' + (uri.port || 443), 
     '-alpn', 
-    'h2'
+    'h2',
+    '-servername',
+    uri.hostname
 
   ];
 
@@ -58,7 +89,7 @@ module.exports = exports = function(payload, fn) {
     try {
 
       // try to pull out the ALPN result
-      var results = alpnRegex.exec(output);
+      var results = output.match(/alpn\s+protocol\:\s+(.*)/gi);
 
       // check if we got a result ?
       if(results && results.length > 1) {
@@ -66,12 +97,22 @@ module.exports = exports = function(payload, fn) {
         // set the actual protocol
         protocol = S(results[1] || '').slugify().s;
 
+      } else if(results && results.length === 1) {
+
+        // if it ends with the protocol
+        if(S(results[0].toLowerCase()).endsWith('h2')) {
+
+          // set the protocol
+          protocol = 'h2';
+
+        }
+
       }
 
     } catch(err) { /** nothing to see here folks **/ }
 
     // If not set to h2 it was not renegotiated
-    if(protocol !== null && protocol !== 'h2') {
+    if(protocol !== 'h2') {
 
       // add the rule
       payload.addRule({

--- a/test/alpn.js
+++ b/test/alpn.js
@@ -40,11 +40,13 @@ describe('alpn', function() {
   });
 
   // handle the error output
-  /* it('Should return a error if the server does not have ALPN enabled', function(done) {
+  it('Should return a error if the server does not have ALPN enabled', function(done) {
+
+    this.timeout(8000);
 
     payload = passmarked.createPayload({
 
-        url: 'https://jacqueskleynhans.com/'
+        url: 'https://example.com/'
 
       }, {}, null);
 
@@ -68,6 +70,6 @@ describe('alpn', function() {
 
     });
 
-  }); */
+  });
 
 });


### PR DESCRIPTION
Updated ALPN to use a timeout while calling OpenSSL to prevent hanging and waiting on nothing.

The timeout uses the package from coreutils, and is configured to use gtimeout on MacOS (if detected). If the platform is not Linux / MacOS we give a warning and return back for now.
