### PR TITLE
GZIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The rules checked in this module are:
 * **favicon.exists** - Favicon does not exists.
 * **favicon.redirect**- Favicon request was redirected instead of just serving.
 * **compress.images** - GZIP was detected on any images on the page.
+* **gzip.internal** - Returned if any CSS or JS assets on the same domain are not gzipped.
+* **gzip.external** - Returned if any CSS or JS assets on a third-party domain are not gzipped.
 * **html** - HTML returned from server was not minified.
 * **h2** - HTTP2 is not supported on server.
 * **h2.blank** - Blank response from HTTP2 server

--- a/lib/rules/gzip.js
+++ b/lib/rules/gzip.js
@@ -1,0 +1,199 @@
+// load modules
+const _             = require('underscore');
+const url           = require('url');
+const zlib          = require('zlib');
+const async         = require('async');
+const request       = require('request');
+const S             = require('string');
+
+/**
+* List of allowed types (css/javascript)
+**/
+var knownTypes = [
+
+  'text/css',
+  'text/javascript',
+  'text/plain',
+  'application/x-javascript'
+
+];
+
+/**
+* Known list of encodings
+**/
+var knownEncodings = [
+  
+  'gzip',
+  'compress',
+  'deflate',
+  'identity',
+  'br'
+
+];
+
+/**
+* handle checking for the cache
+**/
+module.exports = exports = function(payload, fn) {
+
+  // get the data
+  var data = payload.getData();
+
+  // parse our url
+  var uri = url.parse(data.redirected || data.url || '');
+
+  // get the page content
+  payload.getHAR(function(err, har_obj) {
+
+    // did we get a error ?
+    if(err) {
+
+      // low out the error
+      payload.error('Got a error trying to get the HAR', err);
+
+      // done
+      return fn(null);
+
+    }
+
+    // sanity checck
+    if(!har_obj) return fn(null);
+    if(!har_obj.log) return fn(null);
+
+    // parse the url
+    var uri = url.parse(data.url);
+
+    // get the entries
+    var entries = har_obj.log.entries || [];
+
+    // loop all the har entries and check for query strings in the proxy
+    async.eachLimit(entries || [], 10, function(entry, cb) {
+
+      // check the status
+      if(!entry.response) return cb(null);
+      if(!entry.request) return cb(null);
+
+      // build a list of headers based on keys we can use
+      var headers = {};
+
+      // check if this was for a image
+      for(var a = 0; a < (entry.response.headers || []).length; a++) {
+
+        // get the content-encoding header if it exists
+        var name          = (entry.response.headers[a].name || '').toLowerCase();
+        var value         = (entry.response.headers[a].value || '').toLowerCase().split(',')[0];
+
+        // trim out value
+        value             = S(value).trim().s
+
+        // must be in our list of approved names to present
+        // spending too much CPU cycles on this loop ...
+        if([
+
+          'content-type', 'content-encoding'
+
+        ].indexOf(name) == -1) continue;
+
+        // set as names
+        headers[name]     = value;
+
+      }
+
+      // right so if the content type is set
+      if(!headers['content-type']) return cb(null);
+
+      // check if it's a image
+      if(knownTypes.indexOf(headers['content-type']) === -1) return cb(null);
+
+      // right so is this gzipped ?
+      if(knownEncodings.indexOf(headers['content-encoding'] || '') !== -1) return cb(null);
+
+      // check if empty
+      if(S(entry.response.body || '').isEmpty() === true) return cb(null);
+
+      // parse the domain
+      var entryUri = url.parse(entry.response.url || entry.request.url);
+
+      // compress them then and find how much we could save
+      zlib.deflate(entry.response.body, function(err, buf) {
+
+        // check if we got a error
+        if(err) {
+
+          // log the error
+          payload.error('gzip', 'Problem deflating the input', err);
+
+          // finish, not too worried about the error
+          return cb(null);
+
+        }
+
+        // check for the length
+        var originalLen     = Buffer.byteLength(entry.response.body, 'utf8');
+        var resultingLen    = Buffer.byteLength(buf, 'binary');
+
+        // get the percentage between the two
+        var percentage      = (originalLen - resultingLen) / originalLen;
+
+        // if it's bigger than 20% report on it
+        if(percentage >= 0.1) {
+
+          // check if local
+          var isLocal = entryUri.hostname.indexOf(uri.hostname) != -1;
+
+          // add the rule depending on internal or external
+          if(isLocal === true) {
+
+            // add the rule
+            payload.addRule({
+
+                message:        'Enable GZIP to decrease the size of assets that the user has to download from local domain',
+                key:            'gzip.internal',
+                type:           'error'
+
+              }, {
+
+                  message:      'Enabling GZIP on $ could represent a $ saving, reducing the file size from $kb to $kb',
+                  identifiers:  [ url.format(entryUri), originalLen, resultingLen, Math.round(percentage * 100) + '%' ],
+                  url:          url.format(entryUri),
+                  type:         'url'
+
+                });
+
+          } else {
+
+            // add the rule
+            payload.addRule({
+
+                message:        'Enabling GZIP on $ could represent a $ saving, reducing the file size from $kb to $kb',
+                key:            'gzip.external',
+                type:           'notice'
+
+              }, {
+
+                  message:      '$ has compression enabled',
+                  identifiers:  [ url.format(entryUri), originalLen, resultingLen, Math.round(percentage * 100) + '%' ],
+                  url:          url.format(entryUri),
+                  type:         'url'
+
+                });
+
+          }
+
+        }
+
+        // finish strong
+        cb(null);
+
+      });
+
+    }, function() {
+
+      // done
+      fn(null);
+
+    });
+
+  });
+
+};

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -7,6 +7,7 @@ module.exports = exports = [
   require('./charset'),
   require('./consistent'),
   require('./favicon'),
+  require('./gzip'),
   require('./gzip.images'),
   require('./html'),
   require('./http2'),

--- a/samples/gzip.alias.bad.json
+++ b/samples/gzip.alias.bad.json
@@ -1,0 +1,127 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://cdn.example.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196,
+          "body": ".helloworld {} .helloworld2 {} .helloworld3 {} .helloworld4 {}"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.alias.good.json
+++ b/samples/gzip.alias.good.json
@@ -1,0 +1,130 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://cdn.example.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.alias.size.json
+++ b/samples/gzip.alias.size.json
@@ -1,0 +1,127 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://cdn.example.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196,
+          "body": ".helloworld {}"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.external.bad.json
+++ b/samples/gzip.external.bad.json
@@ -1,0 +1,127 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://cdn.example2.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196,
+          "body": ".helloworld {} .helloworld2 {} .helloworld3 {} .helloworld4 {}"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.external.good.json
+++ b/samples/gzip.external.good.json
@@ -1,0 +1,130 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://cdn.example2.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.external.size.json
+++ b/samples/gzip.external.size.json
@@ -1,0 +1,127 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://cdn.example2.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196,
+          "body": ".helloworld {}"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.internal.bad.json
+++ b/samples/gzip.internal.bad.json
@@ -1,0 +1,127 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://example.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196,
+          "body": ".helloworld {} .helloworld2 {} .helloworld3 {} .helloworld4 {}"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.internal.good.json
+++ b/samples/gzip.internal.good.json
@@ -1,0 +1,130 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://example.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/samples/gzip.internal.size.json
+++ b/samples/gzip.internal.size.json
@@ -1,0 +1,127 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "id": "page_2",
+        "title": "http://example.com/",
+        "pageTimings": {
+          "onContentLoad": 433.2439999852795,
+          "onLoad": 1658.8960000080988
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-04-20T21:32:21.709Z",
+        "time": 39.21699998318218,
+        "request": {
+          "method": "GET",
+          "url": "http://example.com/style.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "example.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.8,af;q=0.6,it;q=0.4,tr;q=0.2,sw;q=0.2,fr;q=0.2,cs;q=0.2"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "If-None-Match",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "If-Modified-Since",
+              "value": "Sun, 03 Apr 2016 21:51:28 GMT"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 564,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 20 Apr 2016 21:32:21 GMT"
+            },
+            {
+              "name": "ETag",
+              "value": "\"421818-1af9-52f9b9d3cd800\""
+            },
+            {
+              "name": "Server",
+              "value": "Apache"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css,charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public, max-age=432000"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 6905,
+            "mimeType": "text/css",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": 196,
+          "bodySize": 0,
+          "_transferSize": 196,
+          "body": ".helloworld {}"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.899000006029382,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.08999998681247301,
+          "wait": 36.66800001519734,
+          "receive": 1.5599999751429792,
+          "ssl": -1
+        },
+        "connection": "984401",
+        "pageref": "page_2"
+      }
+    ]
+  }
+}

--- a/test/gzip.js
+++ b/test/gzip.js
@@ -1,0 +1,376 @@
+// modules
+const assert        = require('assert');
+const _             = require('underscore');
+const passmarked        = require('passmarked');
+const testFunc      = require('../lib/rules/gzip');
+
+// checks warnings that we check for
+describe('gzip', function() {
+
+  // handle the error output
+  it('Should not return anything if the HAR is empty', function(done) {
+
+    payload = passmarked.createPayload({
+
+        url: 'http://example.com'
+
+      }, {}, '<p>test</p>');
+
+    // execute the items
+    testFunc(payload, function(err) {
+
+      // check the error
+      if(err) assert.fail('Got a error from the function');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check for a error
+      if(rules.length > 0) assert.fail('Was not expecting a rule ...');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // handle the error output
+  it('Should not return anything if the content is empty', function(done) {
+
+    payload = passmarked.createPayload({
+
+        url: 'http://example.com'
+
+      }, {}, '');
+
+    // execute the items
+    testFunc(payload, function(err) {
+
+      // check the error
+      if(err) assert.fail('Got a error from the function');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check for a error
+      if(rules.length > 0) assert.fail('Was not expecting a rule ...');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // handle the error output
+  it('Should not return anything if the content is null', function(done) {
+
+    payload = passmarked.createPayload({
+
+        url: 'http://example.com'
+
+      }, {}, null);
+
+    // execute the items
+    testFunc(payload, function(err) {
+
+      // check the error
+      if(err) assert.fail('Got a error from the function');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // check for a error
+      if(rules.length > 0) assert.fail('Was not expecting a rule ...');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  describe('internal', function() {
+
+    // handle the error output
+    it('Should not return a error if the [internal] resources were gzipped', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.internal.good.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.internal'; });
+
+        if(rule) assert.fail('Was not expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+    // handle the error output
+    it('Should not return a error if gzipping the [internal] content would have saved less than 10%', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.internal.size.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.internal'; });
+
+        if(rule) assert.fail('Was not expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+    // handle the error output
+    it('Should return a error if gzipping the [internal] content could save more 10%', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.internal.bad.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.internal'; });
+
+        if(!rule) assert.fail('Was expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+  });
+
+  describe('alias', function() {
+
+    // handle the error output
+    it('Should not return a error if the [internal] resources were gzipped, even if on subdomain of same domain', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.alias.good.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.internal'; });
+
+        if(rule) assert.fail('Was not expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+    // handle the error output
+    it('Should not return a error if gzipping the [internal] content would have saved less than 10%, even if on subdomain of same domain', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.alias.size.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.internal'; });
+
+        if(rule) assert.fail('Was not expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+    // handle the error output
+    it('Should return a error if gzipping the [internal] content could save more 10%, even if on subdomain of same domain', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.alias.bad.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.internal'; });
+
+        if(!rule) assert.fail('Was expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+  });
+
+  describe('external', function() {
+
+    // handle the error output
+    it('Should not return a error if the [external] resources were gzipped', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.external.good.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.external'; });
+
+        if(rule) assert.fail('Was not expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+    // handle the error output
+    it('Should not return a error if gzipping the [external] content would have saved less than 10%', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.external.size.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.external'; });
+
+        if(rule) assert.fail('Was not expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+    // handle the error output
+    it('Should return a error if gzipping the [external] content could save more 10%', function(done) {
+
+      payload = passmarked.createPayload({
+
+          url: 'http://example.com'
+
+        }, require('../samples/gzip.external.bad.json'), '<p>test</p>');
+
+      // execute the items
+      testFunc(payload, function(err) {
+
+        // check the error
+        if(err) assert.fail('Got a error from the function');
+
+        // get the rules
+        var rules = payload.getRules();
+
+        // should have one rule
+        var rule = _.find(rules || [], function(item) { return item.key === 'gzip.external'; });
+
+        if(!rule) assert.fail('Was expecting a error');
+
+        // done
+        done();
+
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Added GZIP tests along with docs, this will report back on any `text/css` / `text/javascript` files that do not have gzip enabled from the server. After checking the body and running deflate on the contents ourselves the rule is shown if the user can save more than 10% in the request.

The 10% just stops any false-positives where the GZIP'ped content is actually bigger after running gzip
