### PR TITLE
New cache expiration reference links

### DIFF
--- a/docs/expire.internal.md
+++ b/docs/expire.internal.md
@@ -6,5 +6,5 @@ Consider setting the `Expires` header at least two days in the future. If this i
 
 # Resources
 
-* [Filename based cache busting made easy](http://heatherevens.me.uk/2013/07/01/filename-based-cache-busting-made-easy/)
-* [HTML5 Boilerplate](https://html5boilerplate.com/)
+* [Strategies for Cache-Busting CSS](https://css-tricks.com/strategies-for-cache-busting-css/)
+* [Automatic Cache Busting for Your CSS](https://blog.risingstack.com/automatic-cache-busting-for-your-css/)


### PR DESCRIPTION
Had to update the links over at https://github.com/passmarked/network/blame/develop/docs/expire.internal.md#L9 as the old article over at http://www.heatherevens.me.uk/2013/07/01/filename-based-cache-busting-made-easy/ seems to be 404'ing.

The entire site seems to have reset - http://www.heatherevens.me.uk/. Shame really :|.

--

Also replaced the boilerplate link, as it doesn't quite make sense here. Rather 2 informative blog posts about setting up the expiration header.