### PR TITLE
Release v1.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ The rules checked in this module are:
 
 * **alpn** - ALNP negotiation could not be performed, meaning the protocol is disabled.
 * **bad** - Any of the links in the HAR returned a status code other than REDIRECT/INFO/OK
+* **cache.scope** - The cache-control header specified that the resource is cacheable by both **private** and **public**. Which may cause unindentended behaviour.
+* **cache.unknown** - Unknown options configured apart from known types - [developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control). This will only be triggered on "local" resources, as that is what the user can fix. And browsers will tend to ignore the other options on third parties. This is more the rule being precise.
 * **cache.internal** - Caching on the internal resource is not configured
 * **cache.external** - Caching on the external (third party domain) resource is not configured
+* **expire.date** - The `expire` header contained a invalid date
 * **expire.internal** - The caching duration on a local resource is configured for less than 2 days at a minimum
 * **expire.external** - The caching duration on a external resource is configured for less than 6 hours at a minimum
 * **charset** - Charset could have been set earlier in the headers of the response.

--- a/docs/cache.scope.md
+++ b/docs/cache.scope.md
@@ -1,0 +1,20 @@
+Using `cache-control` developers/website owners can specify precisely how/where and when the resources are allowed to be cached.
+
+Part of these options that can be configured are `private` and `public`, which define:
+
+* `private` that only browsers may cache this resource, meaning the best security as this is per users and proxy servers will ignore these resources.
+* `public` will allow proxies and servers in between to cache and re-use the file.
+
+As is noted, these two differ quite a bit. And as such make no sense being used together, which would only confuse browsers and negate most of the benefits of specifying a specific type.
+
+# How do I fix this ?
+
+Change the `cache-control` header to include only `private` or `public`, not both.
+
+# Resources
+
+* [www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1)
+* [www.mobify.com/blog/beginners-guide-to-http-cache-headers/](http://www.mobify.com/blog/beginners-guide-to-http-cache-headers/)
+* [devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#http-cache-headers](https://devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#http-cache-headers)
+* [stackoverflow.com/questions/3339859/what-is-the-risk-of-having-http-header-cache-control-public](http://stackoverflow.com/questions/3339859/what-is-the-risk-of-having-http-header-cache-control-public)
+* [blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx](http://blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx)

--- a/docs/cache.unknown.md
+++ b/docs/cache.unknown.md
@@ -1,0 +1,43 @@
+The `cache-control` header allows developers/website owners to precisely control where the resources of the site are allowed to be stored/cached and how often they need to be re-validated from the server. 
+
+The header includes numerous options that can be set, normally referred to as `directives`. The supported `directives` commonly used include:
+
+* `public` - Allows proxy servesr to cache the resource, use normally for resources such as images where the data can be public and shared.
+* `private` - Allows only the browser itself to cache the result of the resource, could be seen as more secure as no service in between the service and the user should be caching the result.
+* `no-cache` - Will force browsers to make a request to the server before releasing anything from the cache. Great if you need to be able to log and track usage of a resource while still using caching for performance.
+* `only-if-cached` - Informs the browser to not make any requests to the server.
+* `max-age=<seconds>` - Specifies the number of seconds that this resource should be cached for. We recommend at a bare minimum **4 hours**, while something bigger like **2 days** are advised for shared static resources like images.
+* `s-maxage=<seconds>` - Same as `max-age` but only applies to servers and intermediate services, ignore in the private cache of browsers themselves.
+* `must-revalidate` - Informs the browser to check the server for a new copy of the resource everytime before using it from cache.
+* `proxy-revalidate` - Same as `must-revalidate` but only applies to proxies
+* `no-store` - Informs the browser to not store anything related to the request or the response of the resource in question.
+
+These `directives` can be cherry-picked and combined based on the scenario such as:
+
+```
+Cache-Control: no-cache, no-store, must-revalidate
+```
+
+Which will totally disable caching for resources returned with the header.
+
+Or:
+
+```
+Cache-Control:public, max-age=14400
+```
+
+Which will cache the resource for 4 hours.
+
+
+# How do I fix this ?
+
+Double check the web server congfiguration and what options are included using only the valid options listed above (or from the resources).
+
+# Resources
+
+* [developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+* [www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1)
+* [www.mobify.com/blog/beginners-guide-to-http-cache-headers/](http://www.mobify.com/blog/beginners-guide-to-http-cache-headers/)
+* [devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#http-cache-headers](https://devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#http-cache-headers)
+* [stackoverflow.com/questions/3339859/what-is-the-risk-of-having-http-header-cache-control-public](http://stackoverflow.com/questions/3339859/what-is-the-risk-of-having-http-header-cache-control-public)
+* [blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx](http://blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx)

--- a/docs/expire.date.md
+++ b/docs/expire.date.md
@@ -1,0 +1,17 @@
+The `expiry` header allows developers/website owners to specify a exact date when the resource will no longer be valid, and must be re-fetched from the server.
+
+This header must return a valid date in ISO format. This date needs to be parsed by numerous browsers, so it is good practice to not make any modications and keep with the standards.
+
+The header returned a date that we were not able to parse, which can cause unexpected behaviour in browsers.
+
+# How do I fix this ?
+
+Check your web server, and why the `expiry` header is not returning a actual date that we can parse and check.
+
+# Resources
+
+* [www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1)
+* [www.mobify.com/blog/beginners-guide-to-http-cache-headers/](http://www.mobify.com/blog/beginners-guide-to-http-cache-headers/)
+* [devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#http-cache-headers](https://devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#http-cache-headers)
+* [stackoverflow.com/questions/3339859/what-is-the-risk-of-having-http-header-cache-control-public](http://stackoverflow.com/questions/3339859/what-is-the-risk-of-having-http-header-cache-control-public)
+* [blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx](http://blogs.msdn.com/b/ieinternals/archive/2009/06/17/vary-header-prevents-caching-in-ie.aspx)

--- a/docs/expire.internal.md
+++ b/docs/expire.internal.md
@@ -6,5 +6,5 @@ Consider setting the `Expires` header at least two days in the future. If this i
 
 # Resources
 
-* [Filename based cache busting made easy](http://heatherevens.me.uk/2013/07/01/filename-based-cache-busting-made-easy/)
-* [HTML5 Boilerplate](https://html5boilerplate.com/)
+* [Strategies for Cache-Busting CSS](https://css-tricks.com/strategies-for-cache-busting-css/)
+* [Automatic Cache Busting for Your CSS](https://blog.risingstack.com/automatic-cache-busting-for-your-css/)

--- a/docs/favicon.size.md
+++ b/docs/favicon.size.md
@@ -4,12 +4,22 @@ Favicons should be kept as small as possible making it cacheable and usable by t
 
 Newer browsers allow extra icons to be set either in the [manifest.json](https://developer.mozilla.org/en-US/docs/Web/Manifest) file or meta tags that can define icons for numerous screens sizes.
 
+While HTML5 greatly improves this limit, this error indicates that the file size is over 200kb. Which to us is **way** to big.
+
 # How do I fix this ?
 
-Make sure the favicon at the root of your website (`/favicon`) is small (< 10kb).
+Make sure the favicon at the root of your website (`/favicon.ico`) is smaller than `200kb`.
+
+Several tools exist that are able to generate the sizes required by various devices along with your basic `favicon.ico`:
+
+* [Real Favicon Generator](https://realfavicongenerator.net/) -- **Highly recommended**
+* [Online Favicon Converter](http://tools.dynamicdrive.com/favicon/)
+* [Online Favicon Creator](http://www.favicon.cc/)
 
 # Resources
 
+* [Various sizing information](http://realfavicongenerator.net/faq#why_so_many_files)
+* [Does a favicon have to be 32x32 or 16x16?](http://stackoverflow.com/questions/4014823/does-a-favicon-have-to-be-32x32-or-16x16)
 * [How a bad favicon.ico can cause a lot of trouble](http://techblog.wimgodden.be/2011/02/22/how-a-bad-favicon-ico-can-cause-a-lot-of-trouble/)
 * [Webweaver - Favicons](http://www.webweaver.nu/html-tips/favicon.shtml)
 * [Online Favicon Converter](http://tools.dynamicdrive.com/favicon/)

--- a/lib/rules/cache.js
+++ b/lib/rules/cache.js
@@ -243,6 +243,14 @@ module.exports = exports = function(payload, fn) {
           var values    = value.replace(/\s+/gi, '').split(',');
 
           // check if matches
+          if(values.indexOf('no-cache') != -1)
+            shouldContinue = false;
+
+          // check if matches
+          if(values.indexOf('no-store') != -1)
+            shouldContinue = false;
+
+          // check if matches
           if(values.indexOf('must-revalidate') != -1)
             shouldContinue = false;
 

--- a/lib/rules/cache.js
+++ b/lib/rules/cache.js
@@ -1,10 +1,20 @@
 // load modules
 const _           = require('underscore');
 const url         = require('url');
+const async       = require('async');
 const S           = require('string');
 
-// types to check for cache
-var allowedContentTypes = [ 
+/**
+* Amount of hours we require from the cache
+**/
+const MINIMUM_CACHE_NUMB    = 4;
+const MINIMUM_CACHE_UNITS   = 'hours';
+const MINIMUM_CACHE_TIME    = 60 * 60 * MINIMUM_CACHE_NUMB; // 4 hours
+
+/**
+* types to check for cache
+**/
+const ALLOWED_CONTENT_TYPES = [ 
 
   'application/javascript', 
   'text/javascript', 
@@ -17,25 +27,55 @@ var allowedContentTypes = [
 ];
 
 /**
+* Returns the units and formatted amount in:
+* days / hours / minutes / seconds
+**/
+var getFormattedNumbers = function(timestamp) {
+
+  // get the units
+  var units = null;
+  var number = 0;
+
+  // get the units
+  if(timestamp / 60 / 60 > 24) {
+
+    units   = 'day';
+    number  = Math.round( timestamp / 60 / 60 / 24  );
+
+  } else if(timestamp / 60 / 60 > 1) {
+
+    units   = 'hour';
+    number  = Math.round( timestamp / 60 / 60  );
+
+  } else if(timestamp / 60 > 1) {
+
+    units   = 'minute';
+    number  = Math.round( timestamp / 60  );
+
+  } else {
+
+    units   = 'second';
+    number  = Math.round( timestamp || 0 );
+
+  }
+
+  // check for plurals
+  if(number > 1) units = units + 's';
+
+  // done
+  return {
+
+    unit:     units,
+    number:   number
+
+  }
+
+}
+
+/**
 * Returns the expire header for us to use
 **/
 var getExpireHeader = function(headers) {
-
-  // get the cache control header first
-  for(var i = 0; i < (headers || []).length; i++) {
-
-    // check it
-    if(!headers[i].name) continue;
-
-    // get the headers
-    if((headers[i].name || '').toLowerCase() == 'cache-control') {
-
-      // return the header
-      return headers[i];
-
-    }
-
-  }
 
   // loop to find the expires header
   for(var i = 0; i < (headers || []).length; i++) {
@@ -59,74 +99,397 @@ var getExpireHeader = function(headers) {
 };
 
 /**
-* Returns the max-age as provided by the caching header
+* Returns the expire header for us to use
 **/
-var getMaxAge = function(headers) {
+var getCacheControlHeader = function(headers) {
 
-  // gets the header
-  var header = getExpireHeader(headers);
+  // get the cache control header first
+  for(var i = 0; i < (headers || []).length; i++) {
 
-  // check if we found the header
-  if(header === null || header === undefined)
-    return null;
+    // check it
+    if(!headers[i].name) continue;
 
-  // handle the item
-  var value       = (header.value || '').toLowerCase();
-  var values      = value.replace(/\s+/gi, '').split(',');
+    // get the headers
+    if((headers[i].name || '').toLowerCase() == 'cache-control') {
 
-  // loop and find the max-age
-  for(var i = 0; i < values.length; i++) {
-
-    // check if we have value 
-    if(values[i].indexOf('max-age=') == 0) {
-
-      // get the numbers
-      var numb = values[i].split('=')[1];
-
-      // set the item
-      if( S('' + numb).isEmpty() === false ) {
-
-        try {
-
-          // check the max age
-          var numb = parseInt(numb, 10);
-
-          // check if a number
-          if(numb && 
-              !isNaN(parseFloat(numb)) && 
-                isFinite(numb))
-                  return numb;
-
-        } catch(err) {}
-
-      }
+      // return the header
+      return headers[i];
 
     }
 
   }
 
-  // loop and try to parse the time
-  for(var i = 0; i < values.length; i++) {
+  // done with default
+  return null;
 
-    try {
+};
 
-      // check if valid date
-      var expires = new Date( header.value || 'invalid' );
+/**
+* Returns the max-age as provided by the caching header
+**/
+var processCacheHeaders = function(payload, entry, fn) {
 
-      // check if it's a valid date
-      if(expires.toString() != 'Invalid Date') {
+  // gets the header
+  var cacheControlHeader  = getCacheControlHeader((entry.response || {}).headers || []);
+  var expireHeader        = getCacheControlHeader((entry.response || {}).headers || []);
 
-        // return it
-        return expires.getTime() - new Date().getTime();
+  // get the payload data
+  var data        = payload.getData();
+
+  // parse the urls
+  var uri         = url.parse(data.url);
+
+  // get the url 
+  var entryUrl    = entry.response.url || entry.request.url || '';
+  var entryUri    = url.parse(entryUrl);
+
+  // check the origin
+  var sameOrigin  = uri.hostname ==  entryUri.hostname;
+
+  // the base occurrence
+  var occurrence  = {
+
+    url:        entryUrl,
+    header:     data.url,
+    display:    'url',
+    file:       entryUrl
+
+  };
+
+  // is the cache control header present
+  if(cacheControlHeader) {
+
+    /**
+    * The resulting sections we can output,
+    * pulled from:
+    * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    **/
+    var result = {
+
+      'type':         'cache-control',
+      'directives':   {
+
+        'must-revalidate':          false,
+        'no-cache':                 false,
+        'no-store':                 false,
+        'no-transform':             false,
+        'public':                   false,
+        'private':                  false,
+        'proxy-revalidate':         false,
+        'max-age':                  null,
+        's-maxage':                 null,
+        'immutable':                false,
+        'stale-while-revalidate':   null,
+        'stale-if-error':           null
 
       }
 
-    } catch(err) {}
+    };
+
+    // handle the item
+    var value       = (cacheControlHeader.value || '').toLowerCase();
+    var values      = value.replace(/\s+/gi, '').split(',');
+
+    // loop and find the max-age
+    for(var i = 0; i < values.length; i++) {
+
+      // split, in case this is a equals directive
+      var sections = S(values[i] || '').trim().s.toLowerCase().split('=');
+
+      // check if this is a defined header ... ?
+      if(result['directives'][sections[0]] === undefined) {
+
+        // depending on the origin
+        if(sameOrigin === true) {
+
+          // add the rule
+          // add a missing item
+          payload.addRule({
+
+              type:         'error',
+              message:      'Unknown options configured for caching',
+              key:          'cache.unknown'
+
+            }, _.extend(occurrence, {
+
+              message:      '$ was not recognized',
+              identifiers:  [ sections[0] ]
+
+            }));
+
+        }
+
+        // stop here
+        continue;
+
+      }
+
+      // is there more than one section ?
+      if(sections.length > 1) {
+
+        // try to parse the number
+        var parsedNumber = parseInt(sections[1]);
+
+        // were we able to parse ?
+        if(parsedNumber !== null && 
+            parsedNumber !== NaN && 
+              parsedNumber !== undefined) {
+
+          // set it
+          result['directives'][sections[0]] = parsedNumber;
+
+        }
+
+      } else {
+
+        // set the cache directive
+        result['directives'][sections[0]] = true;
+
+      }
+
+    }
+
+    // do our checks
+    var directives = result['directives'];
+
+    // if defined as public, it makes no sense to define public
+    // and vice versa. Do a quick check to stop this
+    if(directives.private === true && 
+        directives.public === true && 
+          sameOrigin === true) {
+
+      // nope ... show the rule
+      payload.addRule({
+
+        type:         'error',
+        message:      'Cache responded as both private and public',
+        key:          'cache.scope'
+
+      }, _.extend(occurrence, {
+
+        message:      '$ responded as being cachable by both $ and $',
+        identifiers:  [ entryUrl, 'private', 'public' ]
+
+      }));
+
+    }
+
+    // only if we are not instructed to ignore cache
+    /* if(directives['no-store'] == true || 
+        directives['must-revalidate'] == true || 
+          directives['max-age'] === 0 || 
+            directives['max-age'] <= 0) {
+
+      // stop here
+      return fn(null);
+
+    } */
+
+    // debug
+    payload.debug('max-age', 'max-age found was ' + directives['max-age'])
+
+    // if configured 
+    if(directives['max-age'] !== null) {
+
+      // is it smaller than 4 hours ?
+      if(directives['max-age'] === 0 || 
+          directives['max-age'] >= MINIMUM_CACHE_TIME) {
+
+        // debug
+        payload.debug('max-age', 'Skipping as ' + directives['max-age'] + ' > ' + MINIMUM_CACHE_TIME);
+
+        // umm yes ...
+        return fn(null);
+
+      }
+
+      // get the formatted number
+      var formattedNumber = getFormattedNumbers(directives['max-age']);
+
+      // if we found it
+      if(formattedNumber) {
+
+        // check if internal or external
+        if(sameOrigin === true) {
+
+          // add the rule
+          payload.addRule({
+
+              type:         'error',
+              message:      'Caching age on local asset too small',
+              key:          'expire.internal'
+
+            }, _.extend(occurrence, {
+
+              message:      '$ header on $ is only $ ' + formattedNumber.unit + ', expected at the bare minimum $ ' + MINIMUM_CACHE_UNITS,
+              identifiers:  [ 'Cache-Control', entryUrl, Math.round( formattedNumber.number ), MINIMUM_CACHE_NUMB ]
+
+            }));
+
+        } else {
+
+          // add the rule
+          payload.addRule({
+
+              type:         'notice',
+              message:      'Caching age on third-party asset too small',
+              key:          'expire.external'
+
+            }, _.extend(occurrence, {
+
+              message:      '$ header on $ is only $ ' + formattedNumber.unit + ', expected at the bare minimum $ ' + MINIMUM_CACHE_UNITS,
+              identifiers:  [ 'Cache-Control', entryUrl, Math.round( formattedNumber.number ), MINIMUM_CACHE_NUMB ]
+
+            }));
+
+        }
+
+      }
+
+      // finish
+      return fn(null);
+
+    }
+
+  }
+
+  // check if the xpire header is defined
+  if(expireHeader) {
+
+    // try to parse it
+    var expireDate = null;
+
+    // try to parse the header
+    try {
+
+      // parse it
+      expireDate = new Date(expireHeader.value || 'invalid');
+
+    }  catch(err) { /** no luck :(*/ }
+
+    // were we able to parse the date ?
+    if(expireDate === null) {
+
+      if(sameOrigin === true) {
+
+        // nope, show a error
+        payload.addRule({
+
+            type:         'error',
+            message:      'Expire header contains invalid date',
+            key:          'expire.date'
+
+          }, _.extend(occurrence, {
+
+            message:      '$ responded with an invalid date of $',
+            identifiers:  [ entryUrl, expireHeader.value ]
+
+          }));
+
+      }
+
+      // and finish
+      return fn(null);
+
+    }
+
+    // check the time
+    var delta = (new Date().getTime() - expireDate.getTime());
+
+    // must be bigger than 0, just a sanity check
+    if(delta <= 0) return fn(null);
+
+    // is this more than 4 hours
+    if(delta < MINIMUM_CACHE_TIME) {
+
+      // get the formatted number
+      var formattedNumber = getFormattedNumbers(delta);
+
+      // if we found it
+      if(formattedNumber) {
+
+        // check if internal or external
+        if(sameOrigin === true) {
+
+          // add the rule
+          payload.addRule({
+
+              type:         'error',
+              message:      'Caching age on local asset too small',
+              key:          'expire.internal'
+
+            }, _.extend(occurrence, {
+
+              message:      '$ header on $ is only $ ' + formattedNumber.unit + ', expected at the bare minimum $ ' + MINIMUM_CACHE_UNITS,
+              identifiers:  [ 'Expire', entryUrl, Math.round( formattedNumber.number ), MINIMUM_CACHE_NUMB ]
+
+            }));
+
+        } else {
+
+          // add the rule
+          payload.addRule({
+
+              type:         'notice',
+              message:      'Caching age on third-party asset too small',
+              key:          'expire.external'
+
+            }, _.extend(occurrence, {
+
+              message:      '$ header on $ is only $ ' + formattedNumber.unit + ', expected at the bare minimum $ ' + MINIMUM_CACHE_UNITS,
+              identifiers:  [ 'Expire', entryUrl, Math.round( formattedNumber.number ), MINIMUM_CACHE_NUMB ]
+
+            }));
+
+        }
+
+      }
+
+    }
+
+    // done
+    return fn(null);
+
+  } else {
+
+    if(sameOrigin === true) {
+
+      // add a missing item
+      payload.addRule({
+
+          type:         'warning',
+          message:      'Missing cache headers on local asset',
+          key:          'cache.internal'
+
+        }, _.extend(occurrence, {
+
+          message:      '$ nor $ were found on $',
+          identifiers:  [ 'Cache-control', 'Expires', entryUrl ]
+
+        }));
+
+    } else {
+
+      // add a missing item
+      payload.addRule({
+
+          type:         'notice',
+          message:      'Missing cache headers on third party asset',
+          key:          'cache.external'
+
+        }, _.extend(occurrence, {
+
+          message:      '$ nor $ were found on $',
+          identifiers:  [ 'Cache-control', 'Expires', entryUrl ]
+
+        }));
+
+    }
 
   }
 
   // done
-  return null;
+  fn(null);
 
 };
 
@@ -183,21 +546,19 @@ module.exports = exports = function(payload, fn) {
       // parse the url
       var uri = url.parse(data.url)
 
-      // loop the entries
-      for(var i = 0; i < (har.log.entries || []).length; i++) {
+      // walk the entries
+      async.eachLimit(har.log.entries || [], 10, function(entry, cb) {
 
-        // local reference
-        var entry = har.log.entries[i];
-
-        // sanity check
-        if(!entry) continue;
-        if(!entry.request) continue;
-        if(!entry.response) continue;
+        // sanity checks
+        if(!entry) return setImmediate(cb, null);
+        if(!entry.request) return setImmediate(cb, null);
+        if(!entry.response) return setImmediate(cb, null);
 
         // get the entry url
-        var entryUrl          = entry.response.url || entry.request.url || '';
-        var entryUri          = url.parse( entryUrl );
-        var sameOrigin        = uri.hostname ==  entryUri.hostname;
+        var statusCode        = entry.response.status || entry.response.statusCode || null;
+
+        // must be a 200 
+        if(statusCode != 200) return setImmediate(cb, null);
 
         // get the content type
         var contentTypeHeader = _.find(entry.response.headers || [], function(item) {
@@ -208,196 +569,28 @@ module.exports = exports = function(payload, fn) {
         });
 
         // check if we found a header ?
-        if(!contentTypeHeader) continue;
+        if(!contentTypeHeader) return setImmediate(cb, null);
 
         // get the value
         var value = (contentTypeHeader.value || '').toLowerCase();
 
         // check the type
-        if( allowedContentTypes.indexOf(value.split(',')[0]) === -1 ) continue;
+        if( ALLOWED_CONTENT_TYPES.indexOf(value.split(',')[0]) === -1 ) return setImmediate(cb, null);
 
-        // get the max age
-        var maxage = getMaxAge(entry.response.headers || []);
+        // run the process
+        processCacheHeaders(payload, entry, function() {
 
-        // build out the occurrence we will be adding
-        var occurrence = {
+          // done
+          setImmediate(cb, null);
 
-          url: entryUrl,
-          header: data.url,
-          display: 'url'
+        });
 
-        };
+      }, function() {
 
-        // set if we should continue
-        var shouldContinue = true;
+        // done
+        fn(null);
 
-        // if set on demand don't worry about
-        for(var a = 0; a < (entry.response.headers || []).length; a++) {
-
-          // get the cache-control header
-          if((entry.response.headers[a].name || '').toLowerCase() !== 'cache-control')
-            continue;
-
-          // get the value
-          var value     = (entry.response.headers[a].value || '').toLowerCase();
-          var values    = value.replace(/\s+/gi, '').split(',');
-
-          // check if matches
-          if(values.indexOf('no-cache') != -1)
-            shouldContinue = false;
-
-          // check if matches
-          if(values.indexOf('no-store') != -1)
-            shouldContinue = false;
-
-          // check if matches
-          if(values.indexOf('must-revalidate') != -1)
-            shouldContinue = false;
-
-          // check if matches
-          if(values.indexOf('proxy-revalidate') != -1)
-            shouldContinue = false;
-
-          // stop right here
-          break;
-
-        }
-
-        // does this match ?
-        if(shouldContinue === false) continue;
-
-        // must actually have found a max age
-        if(maxage !== null) {
-
-          // get where it is in the content
-          var codeBuild = payload.getSnippetManager().build(lines, -1, entryUri.pathname);
-
-          // add build
-          if(codeBuild) {
-
-            // set the code
-            occurrence.code = codeBuild;
-            occurrence.display = 'code';
-
-          }
-
-          // keep track of the time
-          var expireTimestamp               = 0;
-          var ruleMessage                   = '';
-          var occurrenceMessage             = '';
-          var key                           = '';
-          var level                         = '';
-
-          // get the units
-          var units = null;
-          var number = 0;
-
-          // get the units
-          if(maxage / 60 / 60 > 24) {
-
-            units   = 'day';
-            number  = Math.round( maxage / 60 / 60 / 24  );
-
-          } else if(maxage / 60 / 60 > 1) {
-
-            units   = 'hour';
-            number  = Math.round( maxage / 60 / 60  );
-
-          } else if(maxage / 60 > 1) {
-
-            units   = 'minute';
-            number  = Math.round( maxage / 60  );
-
-          } else {
-
-            units   = 'second';
-            number  = Math.round( maxage );
-
-          }
-
-          /* console.log('max age: ' + maxage);
-          console.log('unit: ' +    units);
-          console.log('number: ' +  number); */
-
-          // add to the unit
-          if(number > 1) units = units + 's';
-
-          // check the timestamp item
-          if(sameOrigin === true) {
-
-            // set to local expire, we expect 2 days at a minimum
-            expireTimestamp   = (60 * 60) * 24 * 2;
-            ruleMessage       = 'Caching age on local asset too small';
-            occurrenceMessage = 'Cache header on $ is only $ ' + units + ', expected at least 2 days';
-            key               = 'expire.internal';
-            level             = 'error';
-
-          } else {
-
-            // set to third party expire, 6 hours
-            expireTimestamp   = (60 * 60) * 6;
-            ruleMessage       = 'Caching age on external asset too small';
-            occurrenceMessage = 'Cache header on $ is only $ ' + units + ', expected at least 6 hours';
-            key               = 'expire.external';
-            level             = 'notice';
-
-          }
-
-          // check if it matches the rule
-          if(maxage <= 0 || maxage > expireTimestamp) continue;
-
-          // add the rule
-          payload.addRule({
-
-              type:     level,
-              message:  ruleMessage,
-              key:      key
-
-            }, _.extend(occurrence, {
-
-              message:      occurrenceMessage,
-              identifiers:  [ entryUrl, Math.round( number  ) ]
-
-            }));
-
-        } else if(sameOrigin === true) {
-
-          // add a missing item
-          payload.addRule({
-
-              type:         'warning',
-              message:      'Missing cache headers on local asset',
-              key:          'cache.internal'
-
-            }, _.extend(occurrence, {
-
-              message:      'Cache header missing on $',
-              identifiers:  [ entryUrl ]
-
-            }));
-
-        } else {
-
-          // add a missing item
-          payload.addRule({
-
-              type:     'notice',
-              message:  'Missing cache headers on third party asset',
-              key:      'cache.external'
-
-            }, _.extend(occurrence, {
-
-              message: 'Cache header missing on $',
-              identifiers: [ entryUrl ]
-
-            }));
-
-        }
-
-      }
-
-      // done
-      fn(null);
+      });
 
     });
 

--- a/lib/rules/cache.js
+++ b/lib/rules/cache.js
@@ -344,7 +344,7 @@ module.exports = exports = function(payload, fn) {
           }
 
           // check if it matches the rule
-          if(maxage > expireTimestamp) continue;
+          if(maxage <= 0 || maxage > expireTimestamp) continue;
 
           // add the rule
           payload.addRule({

--- a/lib/rules/charset.js
+++ b/lib/rules/charset.js
@@ -82,7 +82,7 @@ module.exports = exports = function(payload, fn) {
 
       }, {
 
-        message: 'The content-type returned, $, did not specify the charset',
+        message: '$ did not specify the charset',
         identifiers: [ entry.request.url ],
         url: entry.request.url,
         type: 'url'

--- a/lib/rules/favicon.js
+++ b/lib/rules/favicon.js
@@ -62,6 +62,16 @@ module.exports = exports = function(payload, fn) {
               key:      'favicon.size',
               type:     'warning'
 
+            }, {
+
+              message:      'The favicon at $ was $',
+              identifiers:  [
+
+                faviconPath,
+                (Math.round((parsedLength / 1024) * 100) / 100) + 'kb'
+
+              ]
+
             })
 
           }

--- a/lib/rules/favicon.js
+++ b/lib/rules/favicon.js
@@ -53,7 +53,7 @@ module.exports = exports = function(payload, fn) {
               parsedLength !== undefined) {
 
           // check if we can use it
-          if(parsedLength > 1024 * 10) {
+          if(parsedLength > 1024 * 200) {
 
             // add in the favicon item
             payload.addRule({

--- a/lib/rules/http2.js
+++ b/lib/rules/http2.js
@@ -161,7 +161,7 @@ module.exports = exports = function(payload, fn) {
           var $ = cheerio.load(content);
 
           // get all the head links
-          $('head > link, head > script').each(function() {
+          $('head > link[rel=stylesheet], head > script').each(function() {
 
             // get the url
             var resourceUrl = $(this).attr('href') || $(this).attr('src') || '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passmarked/network",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Rules that check if the network is configured for the best performance",
   "main": "index.js",
   "engines": {

--- a/samples/cache.external.zero.json
+++ b/samples/cache.external.zero.json
@@ -94,7 +94,7 @@
             },
             {
               "name": "Cache-Control",
-              "value": "max-age=5"
+              "value": "max-age=0"
             }
           ],
           "cookies": [],

--- a/samples/cache.local.expire.json
+++ b/samples/cache.local.expire.json
@@ -94,7 +94,7 @@
             },
             {
               "name": "Cache-Control",
-              "value": "max-age=0"
+              "value": "max-age=5"
             }
           ],
           "cookies": [],

--- a/test/cache.js
+++ b/test/cache.js
@@ -132,7 +132,7 @@ describe('cache', function() {
   });
 
   // handle the error output
-  it('If the max age is more than 2 days but on seperate day should not produce a error', function(done) {
+  it('If the max age is more than 2 days but on seperate domain should not produce a error', function(done) {
 
     payload = passmarked.createPayload({
 
@@ -253,6 +253,37 @@ describe('cache', function() {
 
       // check for a error
       if(rule) assert.fail('Should not have gotten a error from the function');
+
+      // done
+      done();
+
+    });
+
+  });
+
+  // handle the error output
+  it('Should return a error if external resource has a max-age 0', function(done) {
+
+    payload = passmarked.createPayload({
+
+        url: 'http://example.com'
+
+      }, require('../samples/cache.external.zero.json'), '<p>test</p>');
+
+    // execute the items
+    testFunc(payload, function(err) {
+
+      // check the error
+      if(err) assert.fail('Got a error from the test');
+
+      // get the rules
+      var rules = payload.getRules();
+
+      // should have one rule
+      var rule = _.find(rules || [], function(item) { return item.key === 'expire.external'; });
+
+      // check for a error
+      if(rule) assert.fail('Was not expecting a error for less than 6 hours');
 
       // done
       done();

--- a/test/favicon.js
+++ b/test/favicon.js
@@ -72,7 +72,7 @@ describe('favicon', function() {
       res.statusCode = 200;
       res.setHeader('Content-Type', 'application/ico');
       request({
-          url: 'http://static.passmarked.com/logo256.png'
+          url: 'http://static.passmarked.com/assets/bg.jpg'
       }).on('error', function(e) {
           res.end(e);
       }).pipe(res);


### PR DESCRIPTION
Non-breaking release to address several problems that have been reported on the module:

* Updates to fix the broken links under the expire.internal.md documentation - thanks @m-bodmer
* HTTP 2 push resources check for only assets, this was a problem as it was checking actual links
* Updates to the favicon rules to allow much bigger files `200kb`
* Updated to support max-age=0
* Updated to avoid issues with external caching urls
* Updated with caching on various smaller parts going out